### PR TITLE
New health values

### DIFF
--- a/Modules/IsleOfConquest.lua
+++ b/Modules/IsleOfConquest.lua
@@ -6,7 +6,7 @@ do
 end
 
 local SendAddonMessage = C_ChatInfo.SendAddonMessage
-local baseGateHealth = 1946880
+local baseGateHealth = 2336256
 local lowestAllianceHp, lowestHordeHp = baseGateHealth, baseGateHealth
 local hordeGates, allianceGates = {}, {}
 local hordeGateBar, allianceGateBar = nil, nil

--- a/Modules/Wintergrasp.lua
+++ b/Modules/Wintergrasp.lua
@@ -20,7 +20,7 @@ local poiWallNames = { -- wall section locations
 	[6030] = L.innerEast, [6029] = L.innerEast, [6028] = L.innerEast,
 	[6056] = L.southGate, [6027] = L.mainEntrance, -- front gate and fortress door
 }
-local baseTowerHealth, mainEntranceHealth, wallHealth, defenseTowerHealth = 130000, 91000, 301000, 81000
+local baseTowerHealth, mainEntranceHealth, wallHealth, defenseTowerHealth = 130000, 91000, 240800, 81000
 local towers, onDemandTrackers = {}, {}
 local towerNames = {
 	["308062"] = L.westTower, -- Shadowsight Tower (West)


### PR DESCRIPTION
https://news.blizzard.com/en-us/world-of-warcraft/23639755/updated-march-8-9-0-5-update-notes#item8

- **Isle of Conquest**: The amount of siege damage required to break down keep walls has been increased by 20%.
- **Wintergrasp**: Wintergrasp Wall, Wintergrasp Fortress Wall, and Wintergrasp Fortress Gate health has been reduced by 20%.