### PR TITLE
Don't clamp the frame to the screen

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -891,7 +891,6 @@ do
 	frame:SetMovable(true)
 	frame:EnableMouse(true)
 	frame:RegisterForDrag("LeftButton")
-	frame:SetClampedToScreen(true)
 	frame:Show()
 	local tooltip = CreateFrame("GameTooltip", "CappingTooltip", UIParent, "GameTooltipTemplate")
 	frame:SetScript("OnEnter", function(f)


### PR DESCRIPTION
Because the AddOn always makes space for the draggable positioning bar above the timer bars, even though it isn't visible when the AddOn is locked, clamping it to the screen prevents users from having the timer bars actually start at the top of the screen. There's always an empty gap at the top.

This change allows you to drag the AddOn so that it technically starts off-screen, but the timer bars start where you want them.

Another solution would be to steal these movement features of BigWigs:

* Make the moving bar appear in the first timer bar's slot when unlocked.
* Add absolute positioning sliders to the options

This was a much smaller first pass that will work if we're willing to live with someone being able to hide it from themselves if they go messing around with manually editing their config files without knowing what they're doing. If that's unacceptable, or there's some other scenario I haven't thought of, I can try the other approach instead.