### PR TITLE
Fix WOTLK IoC gate health

### DIFF
--- a/Modules/IsleOfConquest_Wrath.lua
+++ b/Modules/IsleOfConquest_Wrath.lua
@@ -6,7 +6,7 @@ do
 end
 
 local SendAddonMessage = C_ChatInfo.SendAddonMessage
-local baseGateHealth = 2400000
+local baseGateHealth = 600000
 local lowestAllianceHp, lowestHordeHp = baseGateHealth, baseGateHealth
 local hordeGates, allianceGates = {}, {}
 local hordeGateBar, allianceGateBar = nil, nil


### PR DESCRIPTION
Gate health in Isle of Conquest in WOTLK is 600,000 health. The current value is the retail value.